### PR TITLE
initial changes for x64 build:

### DIFF
--- a/NppPlugin/src/StaticDialog.cpp
+++ b/NppPlugin/src/StaticDialog.cpp
@@ -89,7 +89,7 @@ BOOL CALLBACK StaticDialog::dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPAR
 		{
 			StaticDialog *pStaticDlg = (StaticDialog *)(lParam);
 			pStaticDlg->_hSelf = hwnd;
-			::SetWindowLong(hwnd, GWL_USERDATA, (long)lParam);
+			::SetWindowLongPtr(hwnd, GWLP_USERDATA, lParam);
 			::GetWindowRect(hwnd, &(pStaticDlg->_rc));
             pStaticDlg->run_dlgProc(hwnd, message, wParam, lParam);
 			
@@ -98,7 +98,7 @@ BOOL CALLBACK StaticDialog::dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPAR
 
 		default :
 		{
-			StaticDialog *pStaticDlg = reinterpret_cast<StaticDialog *>(::GetWindowLongPtr(hwnd, GWL_USERDATA));
+			StaticDialog *pStaticDlg = reinterpret_cast<StaticDialog *>(::GetWindowLongPtr(hwnd, GWLP_USERDATA));
 			if (!pStaticDlg)
 				return FALSE;
 			return pStaticDlg->run_dlgProc(hwnd, message, wParam, lParam);

--- a/gpup/src/ProgressDialog.cpp
+++ b/gpup/src/ProgressDialog.cpp
@@ -64,13 +64,13 @@ BOOL CALLBACK ProgressDialog::dlgProc(HWND hWnd, UINT message, WPARAM wParam, LP
 	{
 		case WM_INITDIALOG:
 		{
-			::SetWindowLongPtr(hWnd, GWL_USERDATA, (LONG)lParam);
+			::SetWindowLongPtr(hWnd, GWLP_USERDATA, lParam);
 			ProgressDialog* dlg = reinterpret_cast<ProgressDialog*>(lParam);
 			return dlg->runDlgProc(hWnd, message, wParam, lParam);
 		}
 		default:
 		{
-			ProgressDialog* dlg = reinterpret_cast<ProgressDialog*>(static_cast<LONG_PTR>(::GetWindowLongPtr(hWnd, GWL_USERDATA)));
+			ProgressDialog* dlg = reinterpret_cast<ProgressDialog*>(static_cast<LONG_PTR>(::GetWindowLongPtr(hWnd, GWLP_USERDATA)));
 			return dlg->runDlgProc(hWnd, message, wParam, lParam);
 		}
 	}

--- a/pluginManager/src/ProgressDialog.cpp
+++ b/pluginManager/src/ProgressDialog.cpp
@@ -64,7 +64,7 @@ BOOL CALLBACK ProgressDialog::dlgProc(HWND hWnd, UINT message, WPARAM wParam, LP
 	{
 		case WM_INITDIALOG:
 		{
-			::SetWindowLongPtr(hWnd, GWL_USERDATA, lParam);
+			::SetWindowLongPtr(hWnd, GWLP_USERDATA, lParam);
 			ProgressDialog* dlg = reinterpret_cast<ProgressDialog*>(lParam);
 			return dlg->runDlgProc(hWnd, message, wParam, lParam);
 		}
@@ -74,7 +74,7 @@ BOOL CALLBACK ProgressDialog::dlgProc(HWND hWnd, UINT message, WPARAM wParam, LP
                 if (IDCANCEL == wParam) {
                     int mbResult = MessageBox(hWnd, _T("Are you sure you wish to abort the current installation/removal?"), _T("Cancel installation / removal?"), MB_YESNO | MB_ICONQUESTION);
                     if (IDYES == mbResult) {
-			            ProgressDialog* dlg = reinterpret_cast<ProgressDialog*>(::GetWindowLongPtr(hWnd, GWL_USERDATA));
+			            ProgressDialog* dlg = reinterpret_cast<ProgressDialog*>(::GetWindowLongPtr(hWnd, GWLP_USERDATA));
                         dlg->_cancelToken.triggerCancel();
                     }
                 }
@@ -82,7 +82,7 @@ BOOL CALLBACK ProgressDialog::dlgProc(HWND hWnd, UINT message, WPARAM wParam, LP
             }
 		default:
 		{
-			ProgressDialog* dlg = reinterpret_cast<ProgressDialog*>(::GetWindowLongPtr(hWnd, GWL_USERDATA));
+			ProgressDialog* dlg = reinterpret_cast<ProgressDialog*>(::GetWindowLongPtr(hWnd, GWLP_USERDATA));
 			return dlg->runDlgProc(hWnd, message, wParam, lParam);
 		}
 	}

--- a/pluginManager/src/SettingsDialog.cpp
+++ b/pluginManager/src/SettingsDialog.cpp
@@ -34,12 +34,12 @@ BOOL SettingsDialog::dlgProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPar
 	switch(message)
 	{
 		case WM_INITDIALOG:
-			::SetWindowLongPtr(hWnd, GWL_USERDATA, lParam);
+			::SetWindowLongPtr(hWnd, GWLP_USERDATA, lParam);
 			return reinterpret_cast<SettingsDialog*>(lParam)->run_dlgProc(hWnd, message, wParam, lParam);
 
 		default:
 		{
-			SettingsDialog* dlg = reinterpret_cast<SettingsDialog*>(::GetWindowLongPtr(hWnd, GWL_USERDATA));
+			SettingsDialog* dlg = reinterpret_cast<SettingsDialog*>(::GetWindowLongPtr(hWnd, GWLP_USERDATA));
 			if (dlg)
 				return dlg->run_dlgProc(hWnd, message, wParam, lParam);
 			else

--- a/pluginManager/src/pluginmanagerdialog.cpp
+++ b/pluginManager/src/pluginmanagerdialog.cpp
@@ -62,7 +62,7 @@ BOOL CALLBACK PluginManagerDialog::availableTabDlgProc(HWND hWnd, UINT Message, 
 	{
         case WM_INITDIALOG :
 		{
-			::SetWindowLong(hWnd, GWL_USERDATA, lParam);
+			::SetWindowLongPtr(hWnd, GWLP_USERDATA, lParam);
 			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(lParam);
 
 			dlg->_tabs[TAB_AVAILABLE].hListView = ::GetDlgItem(hWnd, IDC_LISTAVAILABLE);	
@@ -103,14 +103,14 @@ BOOL CALLBACK PluginManagerDialog::availableTabDlgProc(HWND hWnd, UINT Message, 
 
 		case WM_SIZE:
 		{
-			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLongPtr(hWnd, GWL_USERDATA));
+			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLongPtr(hWnd, GWLP_USERDATA));
 			dlg->sizeTab(dlg->_tabs[TAB_AVAILABLE], LOWORD(lParam), HIWORD(lParam));
 			return TRUE;
 		}
 
 		case WM_NOTIFY:
 		{
-			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLongPtr(hWnd, GWL_USERDATA));
+			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLongPtr(hWnd, GWLP_USERDATA));
             HWND hwndFrom = ((LPNMHDR)lParam)->hwndFrom;
 
 			if (dlg && ((LPNMHDR)lParam)->hwndFrom == dlg->_tabs[TAB_AVAILABLE].hListView)
@@ -121,7 +121,7 @@ BOOL CALLBACK PluginManagerDialog::availableTabDlgProc(HWND hWnd, UINT Message, 
 
 		case WM_COMMAND:
 		{
-			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLongPtr(hWnd, GWL_USERDATA));
+			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
 			switch(LOWORD(wParam))
 			{
@@ -162,7 +162,7 @@ BOOL CALLBACK PluginManagerDialog::updatesTabDlgProc(HWND hWnd, UINT Message, WP
 	{
         case WM_INITDIALOG :
 		{
-			::SetWindowLong(hWnd, GWL_USERDATA, (LONG)lParam);
+			::SetWindowLongPtr(hWnd, GWLP_USERDATA, lParam);
 			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(lParam);
 
 			dlg->_tabs[TAB_UPDATES].hListView = ::GetDlgItem(hWnd, IDC_LISTUPDATES);	
@@ -205,14 +205,14 @@ BOOL CALLBACK PluginManagerDialog::updatesTabDlgProc(HWND hWnd, UINT Message, WP
 
 		case WM_SIZE:
 		{
-			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLong(hWnd, GWL_USERDATA));
+			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLongPtr(hWnd, GWLP_USERDATA));
 			dlg->sizeTab(dlg->_tabs[TAB_UPDATES], LOWORD(lParam), HIWORD(lParam));
 			return TRUE;
 		}
 
 		case WM_NOTIFY:
 		{
-			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLong(hWnd, GWL_USERDATA));
+			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
 			if (((LPNMHDR)lParam)->hwndFrom == dlg->_tabs[TAB_UPDATES].hListView)
 			{
@@ -225,7 +225,7 @@ BOOL CALLBACK PluginManagerDialog::updatesTabDlgProc(HWND hWnd, UINT Message, WP
 		
 		case WM_COMMAND:
 		{
-			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLong(hWnd, GWL_USERDATA));
+			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
 			switch(LOWORD(wParam))
 			{
@@ -254,7 +254,7 @@ BOOL CALLBACK PluginManagerDialog::installedTabDlgProc(HWND hWnd, UINT Message, 
 	{
         case WM_INITDIALOG :
 		{
-			::SetWindowLongPtr(hWnd, GWL_USERDATA, (LONG_PTR)lParam);
+			::SetWindowLongPtr(hWnd, GWLP_USERDATA, lParam);
 			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(lParam);
 
 			dlg->_tabs[TAB_INSTALLED].hListView = ::GetDlgItem(hWnd, IDC_LISTINSTALLED);	
@@ -304,14 +304,14 @@ BOOL CALLBACK PluginManagerDialog::installedTabDlgProc(HWND hWnd, UINT Message, 
 
 		case WM_SIZE:
 		{
-			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLong(hWnd, GWL_USERDATA));
+			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLongPtr(hWnd, GWLP_USERDATA));
 			dlg->sizeTab(dlg->_tabs[TAB_INSTALLED], LOWORD(lParam), HIWORD(lParam));
 			return TRUE;
 		}
 
 		case WM_NOTIFY:
 		{
-			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLong(hWnd, GWL_USERDATA));
+			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
 			if (((LPNMHDR)lParam)->hwndFrom == dlg->_tabs[TAB_INSTALLED].hListView)
 			{
@@ -325,7 +325,7 @@ BOOL CALLBACK PluginManagerDialog::installedTabDlgProc(HWND hWnd, UINT Message, 
 
 		case WM_COMMAND:
 		{
-			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLong(hWnd, GWL_USERDATA));
+			PluginManagerDialog *dlg = reinterpret_cast<PluginManagerDialog*>(::GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
 			switch(LOWORD(wParam))
 			{
@@ -374,7 +374,7 @@ BOOL CALLBACK PluginManagerDialog::tabWndProc(HWND hWnd, UINT Message, WPARAM wP
 		case WM_SIZE:
 		{
 			
-			DLGHDR *dlgHdr = reinterpret_cast<DLGHDR*>(::GetWindowLongPtr(hWnd, GWL_USERDATA));
+			DLGHDR *dlgHdr = reinterpret_cast<DLGHDR*>(::GetWindowLongPtr(hWnd, GWLP_USERDATA));
 
 
 			dlgHdr->rcDisplay.left = 0;
@@ -394,7 +394,7 @@ BOOL CALLBACK PluginManagerDialog::tabWndProc(HWND hWnd, UINT Message, WPARAM wP
 		}
 
 		default:
-			DLGHDR *dlgHdr = reinterpret_cast<DLGHDR*>(::GetWindowLong(hWnd, GWL_USERDATA));
+			DLGHDR *dlgHdr = reinterpret_cast<DLGHDR*>(::GetWindowLongPtr(hWnd, GWLP_USERDATA));
 			if (dlgHdr->defWndProc)
 				return ::CallWindowProc(dlgHdr->defWndProc, hWnd, Message, wParam, lParam);
 			else
@@ -539,7 +539,7 @@ BOOL CALLBACK PluginManagerDialog::run_dlgProc(HWND hWnd, UINT Message, WPARAM w
 
 void PluginManagerDialog::OnSelChanged(HWND hwndDlg) 
 { 
-    DLGHDR *pHdr = (DLGHDR *) GetWindowLongPtr(hwndDlg, GWL_USERDATA); 
+    DLGHDR *pHdr = (DLGHDR *) GetWindowLongPtr(hwndDlg, GWLP_USERDATA);
     int iSel = TabCtrl_GetCurSel(pHdr->hwndTab); 
  
     // Destroy the current child dialog box, if any. 
@@ -609,10 +609,10 @@ void PluginManagerDialog::initTabControl()
 	// CopyRect(&_tabHeader.rcDisplay, &wi.rcClient);
 
 	// Set the userdata
-	::SetWindowLong(hTabCtrl, GWL_USERDATA, reinterpret_cast<LONG>(&_tabHeader));
+	::SetWindowLongPtr(hTabCtrl, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(&_tabHeader));
 	
-	_tabHeader.defWndProc = reinterpret_cast<WNDPROC>(::GetWindowLong(hTabCtrl, GWL_WNDPROC));
-	::SetWindowLong(hTabCtrl, GWL_WNDPROC, reinterpret_cast<LONG>(tabWndProc));
+	_tabHeader.defWndProc = reinterpret_cast<WNDPROC>(::GetWindowLongPtr(hTabCtrl, GWLP_WNDPROC));
+	::SetWindowLongPtr(hTabCtrl, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(tabWndProc));
 	// Fake a tab change, to show the first tab
 	OnSelChanged(hTabCtrl);
 }


### PR DESCRIPTION
GWL_USERDATA -> GWLP_USERDATA,GWL_WNDPROC -> GWLP_WNDPROC and corresponding
GetWindowLong->GetWindowLongPtr
SetWindowLong-> SetWindowLongPtr and
cast to reinterpret_cast<LONG_PTR>

What do you think about:
- adding appveyor build config, see e.g. https://ci.appveyor.com/project/chcg/npppluginmanager/build/1.0.33 for a build
- removing remaining dependencies to curl
- updating to VS2013 and use c++11 std functionality instead of boost
- use submodule https://github.com/google/googletest, instead of outdated gtest
- use submodule https://github.com/madler/zlib, instead of path property e:\libs\zlib-1.2.8
- maybe update tinyxml -> tinyxml2
- maybe remove ansi build configs, guess this is not needed/supported any longer

For a full functional X64 build this needs further updates of the n++ includes and corresponding files. 
See https://github.com/chcg/nppPluginManager/tree/app_veyor, which includes some of the parts above and depending on the answers the further PRs need to be tailored.