### PR TITLE
basic appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,53 @@
+version: 1.0.{build}
+image: Visual Studio 2015
+
+
+clone_depth: 1
+
+
+environment:
+  matrix:
+  - PlatformToolset: v140_xp
+  - PlatformToolset: v120_xp
+
+platform:
+    #- x64
+    - Win32
+
+configuration:
+    - Release
+    - Debug
+
+install:
+    - if "%platform%"=="x64" set archi=amd64
+    - if "%platform%"=="Win32" set archi=x86
+    - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+
+build:
+    parallel: true                  # enable MSBuild parallel builds
+    verbosity: minimal
+
+before_build:
+- ps: |
+    Write-Output "Configuration: $env:CONFIGURATION"
+    Write-Output "Platform: $env:PLATFORM"
+    $generator = switch ($env:PLATFORMTOOLSET)
+    {
+        "v140" {"Visual Studio 14 2015"}
+        "v140_xp" {"Visual Studio 14 2015"}
+        "v120" {"Visual Studio 12 2013"}
+        "v120_xp" {"Visual Studio 12 2013"}
+    }
+    if ($env:PLATFORM -eq "x64")
+    {
+        $generator = "$generator Win64"
+    }
+    
+
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - mkdir unicodeAppDataPlugins\plugins
+    - mkdir unicodeAppDataPlugins\updater
+    - msbuild PluginManager.sln /m /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%"
+

--- a/pluginManager/src/pluginmanagerdialog.cpp
+++ b/pluginManager/src/pluginmanagerdialog.cpp
@@ -539,7 +539,7 @@ BOOL CALLBACK PluginManagerDialog::run_dlgProc(HWND hWnd, UINT Message, WPARAM w
 
 void PluginManagerDialog::OnSelChanged(HWND hwndDlg) 
 { 
-    DLGHDR *pHdr = (DLGHDR *) GetWindowLongPtr(hwndDlg, GWLP_USERDATA);
+    DLGHDR *pHdr = reinterpret_cast<DLGHDR*>(::GetWindowLongPtr(hwndDlg, GWLP_USERDATA));
     int iSel = TabCtrl_GetCurSel(pHdr->hwndTab); 
  
     // Destroy the current child dialog box, if any. 


### PR DESCRIPTION
- review comment from PR #9 from @MAPJe71
- starting point of basic appveyor.yml config, starts builds for xp platform sets, see e.g. https://msdn.microsoft.com/en-us/library/jj851139(v=vs.120).aspx for the compatiblity:

For these operating systems, the supported versions are Windows XP Service Pack 3 (SP3) for x86, Windows XP Service Pack 2 (SP2) for x64, and Windows Server 2003 Service Pack 2 (SP2) for both x86 and x64.

use also v140_xp aka VS2015 to be prepared also for the future
- x64 not yet enabled as vs configs are not yet prepared, also submodule checkout is not yet part of it, will be added with some later PR