### PR TITLE
replace boost by c++11 std equivalents available with VS2013 (cleanup)

### DIFF
--- a/gpup/src/gpup.cpp
+++ b/gpup/src/gpup.cpp
@@ -24,12 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 
-#pragma warning (push)
-#pragma warning (disable : 4512) // assignment operator could not be generated
-#include <boost/bind.hpp>
-#pragma warning (pop)
 
-#include <boost/function.hpp>
 
 
 #include "Options.h"
@@ -55,7 +50,7 @@ ProgressDialog *g_progressDialog;
 
 
 using namespace std;
-using namespace boost;
+using namespace std::placeholders;
 
 
 BOOL parseCommandLine(const TCHAR* cmdLine, Options& options)
@@ -312,7 +307,7 @@ BOOL processActionsFile(const tstring& actionsFile)
 			step = install->FirstChildElement();
 			while (step)
 			{
-				boost::shared_ptr<InstallStep> installStep = installStepFactory.create(step);
+				std::shared_ptr<InstallStep> installStep = installStepFactory.create(step);
 				// Progress to next step
 				step = (TiXmlElement*) install->IterateChildren(step);
 
@@ -325,8 +320,8 @@ BOOL processActionsFile(const tstring& actionsFile)
 				StepStatus stepStatus;
 				stepStatus = installStep->perform(basePath,           // basePath
 												&stillToComplete,   // forGpup (still can't achieve, so basically a fail)
-												boost::bind(&setStatus, _1),     // status update function
-												boost::bind(&stepProgress, _1),
+												std::bind(&setStatus, _1),     // status update function
+												std::bind(&stepProgress, _1),
 												&moduleInfo,
 												cancelToken); // step progress function
 
@@ -339,8 +334,8 @@ BOOL processActionsFile(const tstring& actionsFile)
 					++retryCount;
 					stepStatus = installStep->perform(basePath,           // basePath
 												&stillToComplete,   // forGpup (still can't achieve, so basically a fail)
-												boost::bind(&setStatus, _1),     // status update function
-												boost::bind(&stepProgress, _1), // step progress function
+												std::bind(&setStatus, _1),     // status update function
+												std::bind(&stepProgress, _1), // step progress function
 												&moduleInfo,
 												cancelToken); 
 

--- a/gpup/src/stdafx.h
+++ b/gpup/src/stdafx.h
@@ -57,5 +57,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <list>
 
 #include <map>
-#include <boost/shared_ptr.hpp>
+
+#include <functional> // std::bind and std::function
+#include <memory> //std::shared_ptr
 

--- a/libinstall/include/libinstall/CopyStep.h
+++ b/libinstall/include/libinstall/CopyStep.h
@@ -46,8 +46,8 @@ public:
     ~CopyStep() {};
     
     StepStatus perform(tstring& basePath, TiXmlElement* forGpup,
-         boost::function<void(const TCHAR*)> setStatus,
-         boost::function<void(const int)> stepProgress, 
+         std::function<void(const TCHAR*)> setStatus,
+         std::function<void(const int)> stepProgress, 
          const ModuleInfo* moduleInfo, 
          CancelToken& cancelToken);
 
@@ -61,8 +61,8 @@ private:
 
     StepStatus copyDirectory(tstring& fromPath, tstring& toPath, 
                      TiXmlElement* forGpup,
-                     boost::function<void(const TCHAR*)> setStatus,
-                     boost::function<void(const int)> stepProgress, 
+                     std::function<void(const TCHAR*)> setStatus,
+                     std::function<void(const int)> stepProgress, 
                      const ModuleInfo* moduleInfo,
                      CancelToken& cancelToken);
 

--- a/libinstall/include/libinstall/DeleteStep.h
+++ b/libinstall/include/libinstall/DeleteStep.h
@@ -32,8 +32,8 @@ public:
 	~DeleteStep() {};
 	
 	StepStatus perform(tstring& basePath, TiXmlElement* forGpup,
-		boost::function<void(const TCHAR*)> setStatus,
-		boost::function<void(const int)> stepProgress, 
+		std::function<void(const TCHAR*)> setStatus,
+		std::function<void(const int)> stepProgress, 
         const ModuleInfo* moduleInfo,
         CancelToken& cancelToken);
 

--- a/libinstall/include/libinstall/DirectLinkSearch.h
+++ b/libinstall/include/libinstall/DirectLinkSearch.h
@@ -34,7 +34,7 @@ public:
 	DirectLinkSearch(const TCHAR *filename);
 	~DirectLinkSearch();
 
-	boost::shared_ptr<TCHAR> search(const TCHAR *filename);
+	std::shared_ptr<TCHAR> search(const TCHAR *filename);
 
 
 private:

--- a/libinstall/include/libinstall/DownloadManager.h
+++ b/libinstall/include/libinstall/DownloadManager.h
@@ -34,13 +34,13 @@ public:
     void cancelDownload();
     void disableCache();
 
-    void setProgressFunction(boost::function<void(int)> progressFunction);
+    void setProgressFunction(std::function<void(int)> progressFunction);
 
     static void setUserAgent(const TCHAR* userAgent);
 
 
 private:
-    boost::function<void(int)> _progressFunction;
+    std::function<void(int)> _progressFunction;
     BOOL					   _progressFunctionSet;
     static tstring				_userAgent;
 

--- a/libinstall/include/libinstall/DownloadStep.h
+++ b/libinstall/include/libinstall/DownloadStep.h
@@ -31,8 +31,8 @@ public:
 	~DownloadStep() {};
 	
 	StepStatus perform(tstring& basePath, TiXmlElement* forGpup,
-		boost::function<void(const TCHAR*)> setStatus,
-    	boost::function<void(const int)> stepProgress, 
+		std::function<void(const TCHAR*)> setStatus,
+    	std::function<void(const int)> stepProgress, 
         const ModuleInfo *moduleInfo,
         CancelToken& cancelToken);
 

--- a/libinstall/include/libinstall/FileBuffer.h
+++ b/libinstall/include/libinstall/FileBuffer.h
@@ -21,7 +21,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define _FILEBUFFER_H
 
 #define FILEBUFFER_EOF	  CHAR_MAX
-using namespace std;
 
 class FileBuffer
 {
@@ -34,8 +33,8 @@ public:
 	char getCharAt(size_t position);
 
 private:
-	ifstream _file;
-	boost::shared_ptr<char> _buffer;
+	std::ifstream _file;
+	std::shared_ptr<char> _buffer;
 
 	size_t _currentBufferStart;
 	size_t _bufferLength;

--- a/libinstall/include/libinstall/InstallStep.h
+++ b/libinstall/include/libinstall/InstallStep.h
@@ -20,7 +20,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #ifndef _INSTALLSTEP_H
 #define _INSTALLSTEP_H
 
-#include <boost/function.hpp>
 #include "tstring.h"
 #include "tinyxml/tinyxml.h"
 
@@ -44,14 +43,14 @@ public:
 	~InstallStep() {};
 
 	virtual StepStatus perform(tstring &/*basePath*/, TiXmlElement* /*forGpup*/, 
-		boost::function<void(const TCHAR*)> /* setStatus */,
-		boost::function<void(const int)> /* stepProgress */,
+		std::function<void(const TCHAR*)> /* setStatus */,
+		std::function<void(const int)> /* stepProgress */,
 		const ModuleInfo* /*windowParent */,
         CancelToken& /* cancelToken */) { return STEPSTATUS_SUCCESS; };
 
 	virtual StepStatus remove(tstring &/*basePath*/, TiXmlElement* /*forGpup*/, 
-		boost::function<void(const TCHAR*)> /* setStatus */,
-		boost::function<void(const int)> /* stepProgress */,
+		std::function<void(const TCHAR*)> /* setStatus */,
+		std::function<void(const int)> /* stepProgress */,
 		const ModuleInfo* /*windowParent */) { return STEPSTATUS_SUCCESS; };
 
 	virtual void replaceVariables(VariableHandler* /*variableHandler*/) { };

--- a/libinstall/include/libinstall/InstallStepFactory.h
+++ b/libinstall/include/libinstall/InstallStepFactory.h
@@ -32,7 +32,7 @@ class InstallStepFactory
 public:
 	InstallStepFactory(VariableHandler* handler);
 
-	boost::shared_ptr<InstallStep> create(TiXmlElement* element);
+	std::shared_ptr<InstallStep> create(TiXmlElement* element);
 
 private:
 	VariableHandler* _variableHandler;

--- a/libinstall/include/libinstall/RunStep.h
+++ b/libinstall/include/libinstall/RunStep.h
@@ -32,8 +32,8 @@ public:
     ~RunStep() {};
     
     StepStatus perform(tstring& basePath, TiXmlElement* forGpup,
-        boost::function<void(const TCHAR*)> setStatus,
-        boost::function<void(const int)> stepProgress, 
+        std::function<void(const TCHAR*)> setStatus,
+        std::function<void(const int)> stepProgress, 
         const ModuleInfo* moduleInfo,
         CancelToken& cancelToken);
 

--- a/libinstall/include/libinstall/WcharMbcsConverter.h
+++ b/libinstall/include/libinstall/WcharMbcsConverter.h
@@ -27,11 +27,11 @@ Modified for inclusion in VS2010 project "Python Script"
 class WcharMbcsConverter {
 public:
 	
-	static boost::shared_ptr<wchar_t> char2wchar(const char* mbStr);
-	static boost::shared_ptr<char>    wchar2char(const wchar_t* wcStr);
+	static std::shared_ptr<wchar_t> char2wchar(const char* mbStr);
+	static std::shared_ptr<char>    wchar2char(const wchar_t* wcStr);
 
-	static boost::shared_ptr<TCHAR>   char2tchar(const char* mbStr);
-	static boost::shared_ptr<char>    tchar2char(const TCHAR* tStr);
+	static std::shared_ptr<TCHAR>   char2tchar(const char* mbStr);
+	static std::shared_ptr<char>    tchar2char(const TCHAR* tStr);
 
 
 };

--- a/libinstall/src/CopyStep.cpp
+++ b/libinstall/src/CopyStep.cpp
@@ -72,8 +72,8 @@ void CopyStep::replaceVariables(VariableHandler *variableHandler)
 
 
 StepStatus CopyStep::perform(tstring &basePath, TiXmlElement* forGpup, 
-							 boost::function<void(const TCHAR*)> setStatus,
-							 boost::function<void(const int)> stepProgress,
+							 std::function<void(const TCHAR*)> setStatus,
+							 std::function<void(const int)> stepProgress,
 							 const ModuleInfo* moduleInfo,
                              CancelToken& cancelToken)
 {
@@ -133,8 +133,8 @@ StepStatus CopyStep::perform(tstring &basePath, TiXmlElement* forGpup,
 
 StepStatus CopyStep::copyDirectory(tstring& fromPath, tstring& toPath, 
 					 TiXmlElement* forGpup,
-					 boost::function<void(const TCHAR*)> setStatus,
-					 boost::function<void(const int)> stepProgress, 
+					 std::function<void(const TCHAR*)> setStatus,
+					 std::function<void(const int)> stepProgress, 
                      const ModuleInfo* moduleInfo,
                      CancelToken& cancelToken)
 {

--- a/libinstall/src/Decompress.cpp
+++ b/libinstall/src/Decompress.cpp
@@ -58,7 +58,7 @@ BOOL Decompress::unzip(const tstring &zipFile, const tstring &destDir)
 			return FALSE;
 		}
 
-		boost::shared_ptr<TCHAR> tFilename = WcharMbcsConverter::char2tchar(filename);
+		std::shared_ptr<TCHAR> tFilename = WcharMbcsConverter::char2tchar(filename);
 	
 
 		if ((tFilename.get())[_tcslen(tFilename.get()) - 1] == _T('/'))
@@ -136,6 +136,6 @@ BOOL Decompress::unzip(const tstring &zipFile, const tstring &destDir)
 
 void Decompress::setString(const tstring &src, std::string &dest)
 {
-	boost::shared_ptr<char> cDest = WcharMbcsConverter::tchar2char(src.c_str());
+	std::shared_ptr<char> cDest = WcharMbcsConverter::tchar2char(src.c_str());
 	dest = cDest.get();
 }

--- a/libinstall/src/DeleteStep.cpp
+++ b/libinstall/src/DeleteStep.cpp
@@ -36,8 +36,8 @@ DeleteStep::DeleteStep(const TCHAR *file, BOOL isDirectory)
 
 
 StepStatus DeleteStep::perform(tstring& /*basePath*/, TiXmlElement* forGpup, 
-							 boost::function<void(const TCHAR*)> setStatus,
-							 boost::function<void(const int)> stepProgress, 
+							 std::function<void(const TCHAR*)> setStatus,
+							 std::function<void(const int)> stepProgress, 
 							 const ModuleInfo* /*moduleInfo*/,
                              CancelToken& /*cancelToken*/)
 {

--- a/libinstall/src/DirectLinkSearch.cpp
+++ b/libinstall/src/DirectLinkSearch.cpp
@@ -41,11 +41,11 @@ DirectLinkSearch::~DirectLinkSearch()
 {
 }
 
-boost::shared_ptr<TCHAR> DirectLinkSearch::search(const TCHAR *filename)
+std::shared_ptr<TCHAR> DirectLinkSearch::search(const TCHAR *filename)
 {
 	if (!filename || !(*filename))
 	{
-		boost::shared_ptr<TCHAR> empty;
+		std::shared_ptr<TCHAR> empty;
 		return empty;
 	}
 	
@@ -79,7 +79,7 @@ boost::shared_ptr<TCHAR> DirectLinkSearch::search(const TCHAR *filename)
 				size_t realPosition = validateDirectLink(currentPosition-checkOffset + 1);
 				if (realPosition != LINK_NOT_VALID)
 				{
-					boost::shared_ptr<TCHAR> buffer(new TCHAR[currentPosition - realPosition + 2]);
+					std::shared_ptr<TCHAR> buffer(new TCHAR[currentPosition - realPosition + 2]);
 					int bufferPosition = 0;
 					while(realPosition <= currentPosition)
 					{
@@ -107,7 +107,7 @@ boost::shared_ptr<TCHAR> DirectLinkSearch::search(const TCHAR *filename)
 		
 	} while (_file.getCharAt(currentPosition) != FILEBUFFER_EOF);
 	
-	boost::shared_ptr<TCHAR> empty;
+	std::shared_ptr<TCHAR> empty;
 	return empty;
 
 }

--- a/libinstall/src/DownloadManager.cpp
+++ b/libinstall/src/DownloadManager.cpp
@@ -27,7 +27,7 @@ void DownloadManager::setUserAgent(const TCHAR* userAgent)
     _userAgent = userAgent;
 }
 
-void DownloadManager::setProgressFunction(boost::function<void(int)> progressFunction)
+void DownloadManager::setProgressFunction(std::function<void(int)> progressFunction)
 {
     _progressFunction = progressFunction;
     _progressFunctionSet = TRUE;

--- a/libinstall/src/DownloadStep.cpp
+++ b/libinstall/src/DownloadStep.cpp
@@ -20,8 +20,8 @@ DownloadStep::DownloadStep(const TCHAR *url, const TCHAR *filename)
 }
 
 StepStatus DownloadStep::perform(tstring &basePath, TiXmlElement* forGpup, 
-                                 boost::function<void(const TCHAR*)> setStatus,
-                                 boost::function<void(const int)> stepProgress, 
+                                 std::function<void(const TCHAR*)> setStatus,
+                                 std::function<void(const int)> stepProgress, 
                                  const ModuleInfo* moduleInfo,
                                  CancelToken &cancelToken)
 {
@@ -65,7 +65,7 @@ StepStatus DownloadStep::perform(tstring &basePath, TiXmlElement* forGpup,
         if (contentType == _T("text/html"))
         {
             DirectLinkSearch linkSearch(downloadFilename.c_str());
-            boost::shared_ptr<TCHAR> realLink;
+            std::shared_ptr<TCHAR> realLink;
             if (!_filename.empty())
             {
                 realLink = linkSearch.search(_filename.c_str());

--- a/libinstall/src/InstallStepFactory.cpp
+++ b/libinstall/src/InstallStepFactory.cpp
@@ -36,9 +36,9 @@ InstallStepFactory::InstallStepFactory(VariableHandler* variableHandler)
 
 
 
-boost::shared_ptr<InstallStep> InstallStepFactory::create(TiXmlElement* element)
+std::shared_ptr<InstallStep> InstallStepFactory::create(TiXmlElement* element)
 {
-	boost::shared_ptr<InstallStep> installStep;
+	std::shared_ptr<InstallStep> installStep;
 
 	if (!_tcscmp(element->Value(), _T("download")) && element->FirstChild())
 	{

--- a/libinstall/src/InternetDownload.cpp
+++ b/libinstall/src/InternetDownload.cpp
@@ -3,7 +3,7 @@
 #include "InternetDownload.h"
 #include "libinstall/CancelToken.h"
 
-InternetDownload::InternetDownload(HWND parentHwnd, const tstring& userAgent, const tstring& url, CancelToken cancelToken, boost::function<void(int)> progressFunction /* = NULL */) 
+InternetDownload::InternetDownload(HWND parentHwnd, const tstring& userAgent, const tstring& url, CancelToken cancelToken, std::function<void(int)> progressFunction /* = NULL */) 
     : m_parentHwnd(parentHwnd),
       m_url(url),
       m_hInternet(NULL),
@@ -169,7 +169,7 @@ DOWNLOAD_STATUS InternetDownload::getData(writeData_t writeData, void *context)
     long bytesWritten = 0;
 
     // Make point-at-which-we-receive-the-headers 5% of the total progress (arbitrarily chosen!)
-    if (!m_progressFunction.empty()) {
+    if (m_progressFunction != nullptr) {
         m_progressFunction(5);
     }
 
@@ -196,7 +196,7 @@ DOWNLOAD_STATUS InternetDownload::getData(writeData_t writeData, void *context)
 
         (*this.*writeData)(buffer, *bytesRead, context);
         bytesWritten += *bytesRead;
-        if (contentLength && !m_progressFunction.empty()) {
+        if (contentLength && m_progressFunction != nullptr) {
             int percent = static_cast<int>((static_cast<double>(bytesWritten) / static_cast<double>(contentLength)) * 95 + 5);
             m_progressFunction(percent);
         }

--- a/libinstall/src/InternetDownload.h
+++ b/libinstall/src/InternetDownload.h
@@ -11,7 +11,7 @@ enum DOWNLOAD_STATUS {
 
 class InternetDownload {
 public:
-    InternetDownload(HWND parentHwnd, const tstring& userAgent, const tstring& url, CancelToken cancelToken, boost::function<void(int)> progressFunction = NULL);
+    InternetDownload(HWND parentHwnd, const tstring& userAgent, const tstring& url, CancelToken cancelToken, std::function<void(int)> progressFunction = NULL);
         
     ~InternetDownload();
 
@@ -44,7 +44,7 @@ private:
 
     DOWNLOAD_STATUS getData(writeData_t writeData, void* context);
 
-    boost::function<void(int)> m_progressFunction;
+    std::function<void(int)> m_progressFunction;
 
     tstring m_url;
     tstring m_userAgent;

--- a/libinstall/src/RunStep.cpp
+++ b/libinstall/src/RunStep.cpp
@@ -39,8 +39,8 @@ RunStep::RunStep(const TCHAR *file, const TCHAR *arguments, BOOL outsideNpp, con
 
 
 StepStatus RunStep::perform(tstring& basePath, TiXmlElement*  forGpup, 
-							 boost::function<void(const TCHAR*)> setStatus,
-							 boost::function<void(const int)> stepProgress, 
+							 std::function<void(const TCHAR*)> setStatus,
+							 std::function<void(const int)> stepProgress, 
 							 const ModuleInfo* moduleInfo,
                              CancelToken& cancelToken)
 {

--- a/libinstall/src/WcharMbcsConverter.cpp
+++ b/libinstall/src/WcharMbcsConverter.cpp
@@ -25,10 +25,10 @@ Modified for inclusion in VS2010 project "Python Script"
 using namespace std;
 
 
-boost::shared_ptr<wchar_t> WcharMbcsConverter::char2wchar(const char* mbStr)
+std::shared_ptr<wchar_t> WcharMbcsConverter::char2wchar(const char* mbStr)
 {
 	
-	boost::shared_ptr<wchar_t> wideCharStr;
+	std::shared_ptr<wchar_t> wideCharStr;
 
 	int len = ::MultiByteToWideChar(CP_UTF8, 0, mbStr, -1, NULL, 0);
 	
@@ -48,10 +48,10 @@ boost::shared_ptr<wchar_t> WcharMbcsConverter::char2wchar(const char* mbStr)
 }
 
 
-boost::shared_ptr<char> WcharMbcsConverter::wchar2char(const wchar_t* wcStr)
+std::shared_ptr<char> WcharMbcsConverter::wchar2char(const wchar_t* wcStr)
 {
 
-	boost::shared_ptr<char> multiByteStr;
+	std::shared_ptr<char> multiByteStr;
 
 	int len = WideCharToMultiByte(CP_UTF8, 0, wcStr, -1, NULL, 0, NULL, NULL);
 
@@ -69,27 +69,27 @@ boost::shared_ptr<char> WcharMbcsConverter::wchar2char(const wchar_t* wcStr)
 	return multiByteStr;
 }
 
-	//static boost::shared_ptr<const TCHAR>   char2tchar(const char* mbStr);
-	//static boost::shared_ptr<const char>    tchar2char(const TCHAR* tStr);
-boost::shared_ptr<TCHAR> WcharMbcsConverter::char2tchar(const char* mbStr)
+	//static std::shared_ptr<const TCHAR>   char2tchar(const char* mbStr);
+	//static std::shared_ptr<const char>    tchar2char(const TCHAR* tStr);
+std::shared_ptr<TCHAR> WcharMbcsConverter::char2tchar(const char* mbStr)
 {
 #ifdef _UNICODE
 	return char2wchar(mbStr);
 #else
 	int len = strlen(mbStr) + 1;
-	boost::shared_ptr<TCHAR> result(new TCHAR[len]);
+	std::shared_ptr<TCHAR> result(new TCHAR[len]);
 	strcpy_s(result.get(), len, mbStr);
 	return result;
 #endif
 }
 
-boost::shared_ptr<char> WcharMbcsConverter::tchar2char(const TCHAR* tStr)
+std::shared_ptr<char> WcharMbcsConverter::tchar2char(const TCHAR* tStr)
 {
 #ifdef _UNICODE
 	return wchar2char(tStr);
 #else
 	int len = _tcslen(tStr) + 1;
-	boost::shared_ptr<TCHAR> result(new TCHAR[len]);
+	std::shared_ptr<TCHAR> result(new TCHAR[len]);
 	strcpy_s(result.get(), len, tStr);
 	return result;
 #endif

--- a/libinstall/src/precompiled_headers.h
+++ b/libinstall/src/precompiled_headers.h
@@ -26,14 +26,8 @@
 typedef std::basic_string<TCHAR>			tstring;
 
 
+#include <functional> // std::bind and std::function
 
-#pragma warning (push)
-#pragma warning (disable : 4512) // assignment operator could not be generated
-#include <boost/bind.hpp>
-#pragma warning (pop)
-
-#include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <sstream>
 

--- a/paths.props
+++ b/paths.props
@@ -3,23 +3,19 @@
   <ImportGroup Label="PropertySheets" />
   
   <PropertyGroup Label="UserMacros">
-    <BoostPath>e:\libs\boost</BoostPath>
 	<ZlibPath>e:\libs\zlib-1.2.8</ZlibPath>
 	<TestNotepadPlusPlusUnicode>E:\NotepadTest\unicode</TestNotepadPlusPlusUnicode>
 	<TestNotepadPlusPlusAnsi>e:\NotepadTest\ansi</TestNotepadPlusPlusAnsi>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)' == 'Debug' Or '$(Configuration)' == 'ANSI-Debug' Or '$(Configuration)' == 'Debug-xml-test' Or '$(Configuration)' == 'ANSI-Debug-xml-test'">
-    <IncludePath>$(BoostPath);$(ZlibPath);$(IncludePath)</IncludePath>
+    <IncludePath>$(ZlibPath);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release' Or '$(Configuration)' == 'ANSI-Release'">
-    <IncludePath>$(BoostPath);$(ZlibPath);$(IncludePath)</IncludePath>
+    <IncludePath>$(ZlibPath);$(IncludePath)</IncludePath>
   </PropertyGroup>
   
   <ItemDefinitionGroup />
   <ItemGroup>
-    <BuildMacro Include="BoostPath">
-      <Value>$(BoostPath)</Value>
-    </BuildMacro>
   </ItemGroup>
 </Project>

--- a/pluginManager/src/NotifyUpdatesDialog.cpp
+++ b/pluginManager/src/NotifyUpdatesDialog.cpp
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "resource.h"
 
 using namespace std;
-using namespace boost;
+using namespace std::placeholders;
 
 void NotifyUpdatesDialog::doDialog()
 {
@@ -96,7 +96,7 @@ BOOL CALLBACK NotifyUpdatesDialog::run_dlgProc(HWND hWnd, UINT Message, WPARAM w
 			{
 				case IDC_IGNORE:
 					{
-						boost::shared_ptr<list<Plugin*> > selectedPlugins = _pluginListView.getSelectedPlugins();
+						std::shared_ptr<list<Plugin*> > selectedPlugins = _pluginListView.getSelectedPlugins();
 						tstring pluginConfigFilename(_pluginList->getVariableHandler()->getVariable(_T("CONFIGDIR")));
 						pluginConfigFilename.append(_T("\\PluginManager.ini"));
 						
@@ -123,7 +123,7 @@ BOOL CALLBACK NotifyUpdatesDialog::run_dlgProc(HWND hWnd, UINT Message, WPARAM w
                         CancelToken cancelToken;
 						ProgressDialog progress(_hInst, 
                             cancelToken,
-							boost::bind(&PluginList::startInstall, _pluginList, _nppData._nppHandle, _1, &_pluginListView, TRUE, cancelToken));
+							std::bind(&PluginList::startInstall, _pluginList, _nppData._nppHandle, _1, &_pluginListView, TRUE, cancelToken));
 						progress.doModal(_hSelf);
 						
 						_pluginListView.removeSelected();

--- a/pluginManager/src/Plugin.cpp
+++ b/pluginManager/src/Plugin.cpp
@@ -26,7 +26,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "tinyxml/tinyxml.h"
 
 using namespace std;
-using namespace boost;
 
 
 Plugin::Plugin(void)
@@ -281,12 +280,12 @@ void Plugin::addBadVersion(const PluginVersion &version, const TCHAR* report)
 }
 
 
-void Plugin::addInstallStep(boost::shared_ptr<InstallStep> step)
+void Plugin::addInstallStep(std::shared_ptr<InstallStep> step)
 {
 	_installSteps.push_back(step);
 }
 
-void Plugin::addRemoveStep(boost::shared_ptr<InstallStep> step)
+void Plugin::addRemoveStep(std::shared_ptr<InstallStep> step)
 {
 	_removeSteps.push_back(step);
 }
@@ -306,9 +305,9 @@ size_t Plugin::getRemoveStepCount()
 
 
 InstallStatus Plugin::install(tstring& basePath, TiXmlElement* forGpup, 
-									  boost::function<void(const TCHAR*)> setStatus,
-									  boost::function<void(const int)> stepProgress,
-									  boost::function<void()> stepComplete,
+									  std::function<void(const TCHAR*)> setStatus,
+									  std::function<void(const int)> stepProgress,
+									  std::function<void()> stepComplete,
 									  const ModuleInfo* moduleInfo,
 									  VariableHandler* variableHandler,
                                       CancelToken& cancelToken)
@@ -320,9 +319,9 @@ InstallStatus Plugin::install(tstring& basePath, TiXmlElement* forGpup,
 
 
 InstallStatus Plugin::remove(tstring& basePath, TiXmlElement* forGpup, 
-									  boost::function<void(const TCHAR*)> setStatus,
-									  boost::function<void(const int)> stepProgress,
-									  boost::function<void()> stepComplete,
+									  std::function<void(const TCHAR*)> setStatus,
+									  std::function<void(const int)> stepProgress,
+									  std::function<void()> stepComplete,
 									  const ModuleInfo* moduleInfo,
 									  VariableHandler* variableHandler,
                                       CancelToken& cancelToken)
@@ -362,9 +361,9 @@ InstallStatus Plugin::remove(tstring& basePath, TiXmlElement* forGpup,
 
 
 InstallStatus Plugin::runSteps(InstallStepContainer steps, tstring& basePath, TiXmlElement* forGpup, 
-									  boost::function<void(const TCHAR*)> setStatus,
-									  boost::function<void(const int)> stepProgress,
-									  boost::function<void()> stepComplete,
+									  std::function<void(const TCHAR*)> setStatus,
+									  std::function<void(const int)> stepProgress,
+									  std::function<void()> stepComplete,
 									  const ModuleInfo* moduleInfo,
 									  VariableHandler* variableHandler,
                                       CancelToken& cancelToken)

--- a/pluginManager/src/Plugin.h
+++ b/pluginManager/src/Plugin.h
@@ -80,23 +80,23 @@ public:
     void			addBadVersion(const PluginVersion &version, const TCHAR* report);
 
     /* installation */
-    void			addInstallStep(boost::shared_ptr<InstallStep> step);
+    void			addInstallStep(std::shared_ptr<InstallStep> step);
     size_t				getInstallStepCount();
     InstallStatus   install(tstring& basePath, TiXmlElement* forGpup, 
-        boost::function<void(const TCHAR*)> setStatus,
-        boost::function<void(const int)> stepProgress,
-        boost::function<void()> stepComplete,
+        std::function<void(const TCHAR*)> setStatus,
+        std::function<void(const int)> stepProgress,
+        std::function<void()> stepComplete,
         const ModuleInfo* moduleInfo,
         VariableHandler* variableHandler,
         CancelToken& cancelToken);
 
     /* removal */
     size_t getRemoveStepCount();
-    void addRemoveStep(boost::shared_ptr<InstallStep> step);
+    void addRemoveStep(std::shared_ptr<InstallStep> step);
     InstallStatus remove(tstring& basePath, TiXmlElement* forGpup, 
-                                      boost::function<void(const TCHAR*)> setStatus,
-                                      boost::function<void(const int)> stepProgress,
-                                      boost::function<void()> stepComplete,
+                                      std::function<void(const TCHAR*)> setStatus,
+                                      std::function<void(const int)> stepProgress,
+                                      std::function<void()> stepComplete,
                                       const ModuleInfo* moduleInfo,
                                       VariableHandler* variableHandler,
                                       CancelToken& cancelToken);
@@ -134,7 +134,7 @@ private:
     std::map<tstring, PluginVersion>  _versionMap;
     std::map<PluginVersion, tstring>  _badVersionMap;
 
-    typedef std::list<boost::shared_ptr<InstallStep> > InstallStepContainer;
+    typedef std::list<std::shared_ptr<InstallStep> > InstallStepContainer;
 
     InstallStepContainer	_installSteps;
     InstallStepContainer	_removeSteps;
@@ -144,9 +144,9 @@ private:
     
     /* Step Runner for install/remove */
     InstallStatus runSteps(InstallStepContainer steps, tstring& basePath, TiXmlElement* forGpup, 
-                                      boost::function<void(const TCHAR*)> setStatus,
-                                      boost::function<void(const int)> stepProgress,
-                                      boost::function<void()> stepComplete,
+                                      std::function<void(const TCHAR*)> setStatus,
+                                      std::function<void(const int)> stepProgress,
+                                      std::function<void()> stepComplete,
                                       const ModuleInfo* moduleInfo,
                                       VariableHandler* variableHandler,
                                       CancelToken& cancelToken);

--- a/pluginManager/src/PluginList.cpp
+++ b/pluginManager/src/PluginList.cpp
@@ -36,6 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
 using namespace std;
+using namespace std::placeholders;
 
 typedef BOOL (__cdecl * PFUNCISUNICODE)();
 
@@ -395,7 +396,7 @@ void PluginList::addSteps(Plugin* plugin, TiXmlElement* installElement, InstallO
 		else 
 		{
 
-			boost::shared_ptr<InstallStep> installStep = installStepFactory.create(installStepElement);
+			std::shared_ptr<InstallStep> installStep = installStepFactory.create(installStepElement);
 			if (installStep.get()) 
 			{
 				if (INSTALL == ior)
@@ -792,10 +793,10 @@ BOOL PluginList::isInstallOrUpgrade(const tstring& name)
 
 
 
-boost::shared_ptr< list<tstring> > PluginList::calculateDependencies(boost::shared_ptr< list<Plugin*> > selectedPlugins)
+std::shared_ptr< list<tstring> > PluginList::calculateDependencies(std::shared_ptr< list<Plugin*> > selectedPlugins)
 {
 	set<tstring> toBeInstalled;
-	boost::shared_ptr< list<tstring> > installDueToDepends(new list<tstring>);
+	std::shared_ptr< list<tstring> > installDueToDepends(new list<tstring>);
 
 
 	// First add all selected plugins to a name map
@@ -889,7 +890,7 @@ void PluginList::downloadList()
 	BOOL downloadResult = downloadManager.getUrl(md5Url, serverMD5, &g_options.moduleInfo);
 #endif
 
-	boost::shared_ptr<char> cHashBuffer = WcharMbcsConverter::tchar2char(hashBuffer);
+	std::shared_ptr<char> cHashBuffer = WcharMbcsConverter::tchar2char(hashBuffer);
 
 	
 	if (downloadResult && serverMD5 != cHashBuffer.get())
@@ -1008,7 +1009,7 @@ void PluginList::installPlugins(HWND hMessageBoxParent, ProgressDialog* progress
 	// or, the URL for the XML may have changed
 
 	g_options.moduleInfo.setHParent(hMessageBoxParent);
-	boost::shared_ptr< list<Plugin*> > selectedPlugins = pluginListView->getSelectedPlugins();
+	std::shared_ptr< list<Plugin*> > selectedPlugins = pluginListView->getSelectedPlugins();
 
 	if (selectedPlugins.get() == NULL)
 	{
@@ -1070,7 +1071,7 @@ void PluginList::installPlugins(HWND hMessageBoxParent, ProgressDialog* progress
 	
 	
 
-	boost::shared_ptr< list<tstring> > installDueToDepends = calculateDependencies(selectedPlugins);
+	std::shared_ptr< list<tstring> > installDueToDepends = calculateDependencies(selectedPlugins);
 		
 	if (!installDueToDepends->empty())
 	{
@@ -1210,9 +1211,9 @@ void PluginList::installPlugins(HWND hMessageBoxParent, ProgressDialog* progress
 		}
 
 		InstallStatus status = (*pluginIter)->install(pluginTemp, installElement, 
-			boost::bind(&ProgressDialog::setCurrentStatus, progressDialog, _1),
-			boost::bind(&ProgressDialog::setStepProgress, progressDialog, _1),
-			boost::bind(&ProgressDialog::stepComplete, progressDialog),
+			std::bind(&ProgressDialog::setCurrentStatus, progressDialog, _1),
+			std::bind(&ProgressDialog::setStepProgress, progressDialog, _1),
+			std::bind(&ProgressDialog::stepComplete, progressDialog),
 			&g_options.moduleInfo, 
             _variableHandler,
             cancelToken);
@@ -1312,7 +1313,7 @@ void PluginList::removePlugins(HWND hMessageBoxParent, ProgressDialog* progressD
 	TiXmlDocument* forGpupDoc = getGpupDocument(gpupFile.c_str());
 	TiXmlElement*  installElement = forGpupDoc->FirstChildElement(_T("install"));
 
-	boost::shared_ptr< list<Plugin*> > selectedPlugins = pluginListView->getSelectedPlugins();
+	std::shared_ptr< list<Plugin*> > selectedPlugins = pluginListView->getSelectedPlugins();
 		
 
 	if (selectedPlugins.get() == NULL)
@@ -1346,9 +1347,9 @@ void PluginList::removePlugins(HWND hMessageBoxParent, ProgressDialog* progressD
 		}
 		
 		(*pluginIter)->remove(removeBasePath, installElement, 
-					boost::bind(&ProgressDialog::setCurrentStatus, progressDialog, _1),
-					boost::bind(&ProgressDialog::setStepProgress, progressDialog, _1),
-					boost::bind(&ProgressDialog::stepComplete, progressDialog),
+					std::bind(&ProgressDialog::setCurrentStatus, progressDialog, _1),
+					std::bind(&ProgressDialog::setStepProgress, progressDialog, _1),
+					std::bind(&ProgressDialog::stepComplete, progressDialog),
 					&g_options.moduleInfo, 
                     _variableHandler,
                     cancelToken);

--- a/pluginManager/src/PluginList.h
+++ b/pluginManager/src/PluginList.h
@@ -57,7 +57,7 @@ public:
 /* Checks dependencies on a list of plugins
  *  Any dependencies are added to the list, and a list of names of plugins added is returned
  */
-	boost::shared_ptr< std::list<tstring> > calculateDependencies(boost::shared_ptr< std::list<Plugin*> > selectedPlugins);
+	std::shared_ptr< std::list<tstring> > calculateDependencies(std::shared_ptr< std::list<Plugin*> > selectedPlugins);
 
 	/* Installs or updates given list of plugins, and also includes dependencies 
 	 * Warns user with messageboxes about intended actions

--- a/pluginManager/src/PluginListView.cpp
+++ b/pluginManager/src/PluginListView.cpp
@@ -309,10 +309,10 @@ Plugin* PluginListView::getCurrentPlugin()
 }
 
 
-boost::shared_ptr< list<Plugin*> > PluginListView::getSelectedPlugins()
+std::shared_ptr< list<Plugin*> > PluginListView::getSelectedPlugins()
 {
 	
-	boost::shared_ptr< list<Plugin*> > selectedList;
+	std::shared_ptr< list<Plugin*> > selectedList;
 	
 	if (_listMode == LISTMODE_MESSAGE)
 		return selectedList;

--- a/pluginManager/src/PluginListView.h
+++ b/pluginManager/src/PluginListView.h
@@ -45,7 +45,7 @@ public:
 	void	setMessage(TCHAR *msg);
 	LRESULT notify(WPARAM wParam, LPARAM lParam);
 	Plugin* getCurrentPlugin();
-	boost::shared_ptr< std::list<Plugin*> > getSelectedPlugins();
+	std::shared_ptr< std::list<Plugin*> > getSelectedPlugins();
 	BOOL    empty();
 	
 

--- a/pluginManager/src/PluginManagerDialog.h
+++ b/pluginManager/src/PluginManagerDialog.h
@@ -114,7 +114,7 @@ private:
 
     BOOL _isDownloading;
     uintptr_t _downloadThread;
-    std::list<boost::shared_ptr<POSITIONINFO>> _bottomComponents;
+    std::list<std::shared_ptr<POSITIONINFO>> _bottomComponents;
 
 
 	/* Private methods */

--- a/pluginManager/src/ProgressDialog.cpp
+++ b/pluginManager/src/ProgressDialog.cpp
@@ -23,9 +23,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "libinstall/CancelToken.h"
 
 
-using namespace boost;
 
-ProgressDialog::ProgressDialog(HINSTANCE hInst, CancelToken cancelToken, function<void(ProgressDialog*)> startFunction)
+ProgressDialog::ProgressDialog(HINSTANCE hInst, CancelToken cancelToken, std::function<void(ProgressDialog*)> startFunction)
     : _hInst(hInst),
       _startFunction(startFunction),
       _hSelf(0),

--- a/pluginManager/src/ProgressDialog.h
+++ b/pluginManager/src/ProgressDialog.h
@@ -6,7 +6,7 @@
 class ProgressDialog
 {
 public:
-    ProgressDialog(HINSTANCE hInst, CancelToken cancelToken, boost::function<void(ProgressDialog*)> startFunction);
+    ProgressDialog(HINSTANCE hInst, CancelToken cancelToken, std::function<void(ProgressDialog*)> startFunction);
     ~ProgressDialog() {};
 
     void doModal(HWND parent);
@@ -34,7 +34,7 @@ private:
     HINSTANCE	_hInst;
     CancelToken _cancelToken;
 
-    boost::function<void(ProgressDialog*)> _startFunction;
+    std::function<void(ProgressDialog*)> _startFunction;
 
 
     void goToCenter();

--- a/pluginManager/src/WcharMbcsConverter.h
+++ b/pluginManager/src/WcharMbcsConverter.h
@@ -3,11 +3,11 @@
 class WcharMbcsConverter {
 public:
 	
-	static boost::shared_ptr<wchar_t> char2wchar(const char* mbStr);
-	static boost::shared_ptr<char>    wchar2char(const wchar_t* wcStr);
+	static std::shared_ptr<wchar_t> char2wchar(const char* mbStr);
+	static std::shared_ptr<char>    wchar2char(const wchar_t* wcStr);
 	
-	static boost::shared_ptr<TCHAR>   char2tchar(const char* mbStr);
-	static boost::shared_ptr<char>    tchar2char(const TCHAR* tStr);
+	static std::shared_ptr<TCHAR>   char2tchar(const char* mbStr);
+	static std::shared_ptr<char>    tchar2char(const TCHAR* tStr);
 
 
 };

--- a/pluginManager/src/pluginmanagerdialog.cpp
+++ b/pluginManager/src/pluginmanagerdialog.cpp
@@ -37,7 +37,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "WcharMbcsConverter.h"
 
 using namespace std;
-using namespace boost;
+using namespace std::placeholders;
 
 
 PluginManagerDialog::PluginManagerDialog()
@@ -130,7 +130,7 @@ BOOL CALLBACK PluginManagerDialog::availableTabDlgProc(HWND hWnd, UINT Message, 
                     CancelToken cancelToken;
 					ProgressDialog progress(dlg->_hInst, 
                         cancelToken,
-						boost::bind(&PluginList::startInstall, dlg->_pluginList, dlg->_hSelf, _1, &dlg->_availableListView, FALSE, cancelToken));
+						std::bind(&PluginList::startInstall, dlg->_pluginList, dlg->_hSelf, _1, &dlg->_availableListView, FALSE, cancelToken));
 					progress.doModal(dlg->_hSelf);
 					
 					break;
@@ -234,7 +234,7 @@ BOOL CALLBACK PluginManagerDialog::updatesTabDlgProc(HWND hWnd, UINT Message, WP
                     CancelToken cancelToken;
 					ProgressDialog progress(dlg->_hInst, 
                         cancelToken,
-						boost::bind(&PluginList::startInstall, dlg->_pluginList, dlg->_hSelf, _1, &dlg->_updatesListView, TRUE, cancelToken));
+						std::bind(&PluginList::startInstall, dlg->_pluginList, dlg->_hSelf, _1, &dlg->_updatesListView, TRUE, cancelToken));
 					progress.doModal(dlg->_hSelf);
 					
 					
@@ -334,7 +334,7 @@ BOOL CALLBACK PluginManagerDialog::installedTabDlgProc(HWND hWnd, UINT Message, 
                     CancelToken cancelToken;
 					ProgressDialog progress(dlg->_hInst, 
                         cancelToken,
-						boost::bind(&PluginList::startRemove, dlg->_pluginList, dlg->_hSelf, _1, &dlg->_installedListView, cancelToken));
+						std::bind(&PluginList::startRemove, dlg->_pluginList, dlg->_hSelf, _1, &dlg->_installedListView, cancelToken));
 					progress.doModal(dlg->_hSelf);
 					break;
 				}
@@ -344,7 +344,7 @@ BOOL CALLBACK PluginManagerDialog::installedTabDlgProc(HWND hWnd, UINT Message, 
                     CancelToken cancelToken;
 					ProgressDialog progress(dlg->_hInst, 
                         cancelToken,
-						boost::bind(&PluginList::startInstall, dlg->_pluginList, dlg->_hSelf, _1, &dlg->_installedListView, TRUE, cancelToken));
+						std::bind(&PluginList::startInstall, dlg->_pluginList, dlg->_hSelf, _1, &dlg->_installedListView, TRUE, cancelToken));
 					progress.doModal(dlg->_hSelf);
 					break;
 				}
@@ -417,7 +417,7 @@ void PluginManagerDialog::addBottomComponent(HWND hWnd, WINDOWINFO& wiDlg, UINT 
             positionInfo->width = wiCtl.rcClient.right - wiCtl.rcClient.left;
             positionInfo->bottomOffset = wiDlg.rcClient.bottom - wiCtl.rcClient.top;
             positionInfo->leftOffset = wiCtl.rcClient.left - wiDlg.rcClient.left;
-            _bottomComponents.push_back(boost::shared_ptr<POSITIONINFO>(positionInfo));
+            _bottomComponents.push_back(std::shared_ptr<POSITIONINFO>(positionInfo));
 }
 
 BOOL CALLBACK PluginManagerDialog::run_dlgProc(HWND hWnd, UINT Message, WPARAM wParam, LPARAM lParam)
@@ -638,7 +638,7 @@ void PluginManagerDialog::sizeWindow(int width, int height)
 
     
     // Move the sponsor message 
-    for(std::list<boost::shared_ptr<POSITIONINFO>>::iterator it = _bottomComponents.begin(); it != _bottomComponents.end(); it++) {
+    for(std::list<std::shared_ptr<POSITIONINFO>>::iterator it = _bottomComponents.begin(); it != _bottomComponents.end(); it++) {
 		::MoveWindow((*it)->handle, (*it)->leftOffset, height - (*it)->bottomOffset, (*it)->width, (*it)->height, FALSE);
 	}
 	::InvalidateRect(_hSelf, NULL, TRUE);

--- a/pluginManager/src/precompiled_headers.h
+++ b/pluginManager/src/precompiled_headers.h
@@ -17,8 +17,6 @@
 #include <process.h>
 #include <strsafe.h>
 
-#include <boost/bind.hpp>
-#include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
+#include <functional>   // std::bind and std::function
 
 typedef std::basic_string<TCHAR>			tstring;


### PR DESCRIPTION
mergeable clean version of PR #13  
- replace boost:: with std::
- updated the necessary include headers and namespaces
- removed BoostPath from paths.props
