### PR TITLE
X64 pluginlist

### DIFF
--- a/pluginManager/src/PluginList.cpp
+++ b/pluginManager/src/PluginList.cpp
@@ -199,7 +199,7 @@ BOOL PluginList::parsePluginFile(CONST TCHAR *filename)
 				{
 					if (g_isX64)
 					{
-						TiXmlElement *versionUrlElement = pluginNode->FirstChildElement(_T("unicodeX64Version"));
+						TiXmlElement *versionUrlElement = pluginNode->FirstChildElement(_T("X64Version"));
 						if (versionUrlElement && versionUrlElement->FirstChild())
 						{
 							plugin->setVersion(PluginVersion(versionUrlElement->FirstChild()->Value()));
@@ -393,10 +393,11 @@ void PluginList::addSteps(Plugin* plugin, TiXmlElement* installElement, InstallO
 
 	while (installStepElement)
 	{
-		// If it is a unicode tag, then only process the contents if it's a unicode N++
+		// If it is a unicode tag and build for x64, then only process the contents if it's a x64 N++, which is just available for unicode
+		// or if it's an unicode tag and build for x86, then only process the contents if it's an unicode N++
 		// or if it's an ansi tag, then only process the contents if it's an ansi N++
 		if ((g_isUnicode && g_isX64
-			&& !_tcscmp(installStepElement->Value(), _T("unicodeX64")) 
+			&& !_tcscmp(installStepElement->Value(), _T("X64")) 
 			&& installStepElement->FirstChild())
 			||
 			(g_isUnicode

--- a/pluginManager/src/PluginList.cpp
+++ b/pluginManager/src/PluginList.cpp
@@ -197,11 +197,23 @@ BOOL PluginList::parsePluginFile(CONST TCHAR *filename)
 
 				if (g_isUnicode)
 				{
-					TiXmlElement *versionUrlElement = pluginNode->FirstChildElement(_T("unicodeVersion"));
-					if (versionUrlElement && versionUrlElement->FirstChild())
+					if (g_isX64)
 					{
-						plugin->setVersion(PluginVersion(versionUrlElement->FirstChild()->Value()));
-						available = TRUE;
+						TiXmlElement *versionUrlElement = pluginNode->FirstChildElement(_T("unicodeX64Version"));
+						if (versionUrlElement && versionUrlElement->FirstChild())
+						{
+							plugin->setVersion(PluginVersion(versionUrlElement->FirstChild()->Value()));
+							available = TRUE;
+						}
+					}
+					else
+					{
+						TiXmlElement *versionUrlElement = pluginNode->FirstChildElement(_T("unicodeVersion"));
+						if (versionUrlElement && versionUrlElement->FirstChild())
+						{
+							plugin->setVersion(PluginVersion(versionUrlElement->FirstChild()->Value()));
+							available = TRUE;
+						}
 					}
 				}
 				else 
@@ -383,9 +395,13 @@ void PluginList::addSteps(Plugin* plugin, TiXmlElement* installElement, InstallO
 	{
 		// If it is a unicode tag, then only process the contents if it's a unicode N++
 		// or if it's an ansi tag, then only process the contents if it's an ansi N++
-		if ((g_isUnicode 
-			&& !_tcscmp(installStepElement->Value(), _T("unicode")) 
+		if ((g_isUnicode && g_isX64
+			&& !_tcscmp(installStepElement->Value(), _T("unicodeX64")) 
 			&& installStepElement->FirstChild())
+			||
+			(g_isUnicode
+				&& !_tcscmp(installStepElement->Value(), _T("unicode"))
+				&& installStepElement->FirstChild())
 			||
 			(!g_isUnicode
 			&& !_tcscmp(installStepElement->Value(), _T("ansi")) 

--- a/pluginManager/src/PluginManager.cpp
+++ b/pluginManager/src/PluginManager.cpp
@@ -51,6 +51,12 @@ BOOL				g_isUnicode			= TRUE;
 BOOL				g_isUnicode			= FALSE;
 #endif
 
+#ifdef _WIN64
+BOOL				g_isX64 = TRUE;
+#else
+BOOL				g_isX64 = FALSE;
+#endif
+
 Options				g_options;
 SettingsDialog		g_settingsDlg;
 PluginList          *g_pluginList       = NULL;

--- a/pluginManager/src/PluginManager.h
+++ b/pluginManager/src/PluginManager.h
@@ -85,6 +85,7 @@ void doPluginManagerDlg(void);
 
 extern HANDLE g_hModule;
 extern BOOL   g_isUnicode;
+extern BOOL   g_isX64;
 extern winVer g_winVer;
 
 enum INSTALLLOCATION


### PR DESCRIPTION
Added impl for:

Updated xml structure:

```
<plugin name="Plugin Manager">
	<ansiVersion>1.0.8</ansiVersion>
	<unicodeVersion>1.4.3</unicodeVersion>
        <unicodeX64Version>1.4.X</unicodeX64Version>
	<description>The Plugin Manager is this plugin, that allows installation, update and removal of Notepad++ plugins.  	It will notify you of updates to plugins that you have installed, and automatically install dependencies and required 	files into the correct places.</description>
	<author>Dave Brotherstone</author>
	<homepage>http://www.brotherstone.co.uk/npp/pm</homepage>
	<sourceUrl>http://github.com/davegb3/nppPluginManager</sourceUrl>
	<latestUpdate>* Ignore warning about GPUP version on install *\nUpdate to use windows native internet API for downloads\nFix so that after a plugin is installed, Notepad++ will no longer be automatically promoted to run as admin - it will remain with the same privileges it had before plugin installation\nPlease report any issues to the Plugin Development forum https://notepad-plus-plus.org/community/category/5/plugin-development</latestUpdate>
	<install>
		<unicode>
			<download>https://github.com/bruderstein/nppPluginManager/releases/download/v1.4.3/PluginManager_1.4.3_UNI.zip</download>
			<copy from="plugins\PluginManager.dll" to="$PLUGINDIR$\" validate="true"/><copy from="updater\gpup.exe" to="$NPPDIR$\updater" validate="true" replace="true" isGpup="true"/>
		</unicode>
		<unicodeX64>
			<download>https://github.com/bruderstein/nppPluginManager/releases/download/v1.4.X/PluginManager_1.4.X_UNI.zip</download>
			<copy from="plugins\PluginManager.dll" to="$PLUGINDIR$\" validate="true"/><copy from="updater\gpup.exe" to="$NPPDIR$\updater" validate="true" replace="true" isGpup="true"/>
		</unicodeX64>
		<ansi>
		         <download>http://downloads.sourceforge.net/project/npppluginmgr/v1.0.8/PluginManager_1.0.8_ANSI.zip</download>
		         <copy from="plugins\PluginManager.dll" to="$PLUGINDIR$\" validate="true"/><copy from="updater\gpup.exe" to="$NPPDIR$\updater" validate="true" replace="true" isGpup="true"/>
		</ansi>
	</install>
</plugin>
```

- With support for the suggestion for new X64 values:
`<unicodeX64Version>1.4.3</unicodeX64Version> `
`<unicodeX64> download, copy </unicodeX64> ` within install and remove

- @bruderstein 
At least this should be the right code position, which need to be changed. What do you think about the naming of the new xml child nodes? The server side need to be updated accordingly.