### PR TITLE
Fix the registered plugin installed version

### DIFF
--- a/pluginManager/src/PluginList.cpp
+++ b/pluginManager/src/PluginList.cpp
@@ -582,8 +582,13 @@ BOOL PluginList::checkInstalledPlugins(const TCHAR *pluginPath, BOOL allUsers)
 							}
 						}
 
+						// Also update the registered plugin version to the installed version
+						Plugin* registeredPlugin = getPlugin(plugin->getName());
+						if (registeredPlugin) {
+							registeredPlugin->setInstalledVersion(plugin->getInstalledVersion());
+						}	
 					}
-						
+
 
 					if (plugin->getInstalledVersion().getIsBad() 
 						|| plugin->getVersion() > plugin->getInstalledVersion())


### PR DESCRIPTION
When updating the AppData plugins, also update the registered `Plugin` object for the given name. Previously this was not updated, so when the plugin was looked up by name (actually only done for dependencies and checking Plugin Manager updates) the non appdata version was always used. This manifested itself in #54 (and originally in #45), when the plugin manager would ask to update itself, even though it was not showing an update.

Can be seen here fetching the plugin via `getPlugin(name)`, which uses the `_plugins` map:
https://github.com/bruderstein/nppPluginManager/blob/ea8d624827c5f0cb31a8e5cfcb0ef4c4ef00ab3e/pluginManager/src/PluginList.cpp#L1037-L1040