### PR TITLE
Fix issue with plugin list download

### DIFF
--- a/pluginManager/src/PluginList.h
+++ b/pluginManager/src/PluginList.h
@@ -135,5 +135,6 @@ private:
 	void addSteps(Plugin* plugin, TiXmlElement* installElement, InstallOrRemove ior);
 
     TCHAR *getPluginsUrl();
+	TCHAR *getPluginsMd5Url();
     TCHAR *getValidateUrl();
 };


### PR DESCRIPTION
When the plugin list matched the MD5 (which it hasn't done for a while due to a server side issue with the MD5 not being correct!), it would always fail.

The server side issue was corrected, which manifested this issue in the code.

Also, the DEV list MD5 URL wasn't used when the DEV list was selected.

This is the fix for #57 