### PR TITLE
Fix memory leak

### DIFF
--- a/pluginManager/src/Plugin.cpp
+++ b/pluginManager/src/Plugin.cpp
@@ -268,10 +268,9 @@ BOOL Plugin::isInstalled()
 
 void Plugin::addVersion(const TCHAR* hash, const PluginVersion &version)
 {
-	tstring *hashString = new tstring;
-	*hashString = hash;
+	tstring hashString = hash;
 
-	_versionMap[(*hashString)] = version;
+	_versionMap[hashString] = version;
 }
 
 void Plugin::addBadVersion(const PluginVersion &version, const TCHAR* report)

--- a/pluginManager/src/Plugin.cpp
+++ b/pluginManager/src/Plugin.cpp
@@ -268,9 +268,7 @@ BOOL Plugin::isInstalled()
 
 void Plugin::addVersion(const TCHAR* hash, const PluginVersion &version)
 {
-	tstring hashString = hash;
-
-	_versionMap[hashString] = version;
+	_versionMap[hash] = version;
 }
 
 void Plugin::addBadVersion(const PluginVersion &version, const TCHAR* report)


### PR DESCRIPTION
Spotted by cppcheck via @chcg
As the map uses raw `tstring`s, they're copied anyway, so no need to do the pointer dance anyway.