### PR TITLE
Change URL for plugin list MD5

### DIFF
--- a/pluginManager/src/PluginManager.h
+++ b/pluginManager/src/PluginManager.h
@@ -26,12 +26,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "libinstall/ModuleInfo.h"
 
 
-#define PLUGINS_MD5_URL     _T("https://nppxml.bruderste.in/pm/xml/plugins.md5.txt")
-#define PLUGINS_HTTP_MD5_URL     _T("http://nppxml.bruderste.in/pm/xml/plugins.md5.txt")
+#define PLUGINS_MD5_URL     _T("https://nppxml.bruderste.in/pm/xml/plugins2.md5.txt")
+#define PLUGINS_HTTP_MD5_URL     _T("http://nppxml.bruderste.in/pm/xml/plugins2.md5.txt")
 #define PLUGINS_URL         _T("https://nppxml.bruderste.in/pm/xml/plugins.zip")
 #define PLUGINS_HTTP_URL         _T("http://nppxml.bruderste.in/pm/xml/plugins.zip")
 
-#define DEV_PLUGINS_MD5_URL     _T("https://nppxmldev.bruderste.in/pm/xml/plugins.md5.txt")
+#define DEV_PLUGINS_MD5_URL     _T("https://nppxmldev.bruderste.in/pm/xml/plugins2.md5.txt")
 #define DEV_PLUGINS_URL         _T("https://nppxmldev.bruderste.in/pm/xml/plugins.zip")
 
 #ifdef ALLOW_OVERRIDE_XML_URL


### PR DESCRIPTION
Version 1.4.3 through 1.4.6 had an issue where the MD5 had to be
different, and they always were because we were originally creating the
md5sum of the plugins.zip, not the XML. Now we've corrected it,
we need a way for the hash to remain "wrong" for
1.4.3 through 1.4.6, but correct for 1.4.8 onwards.

Changing the URL for the MD5 is how we're doing that, so plugins.md5.txt
still exists, but it contains an old hash that will never be correct.

plugins2.md5.txt contains the correct hash