### PR TITLE
Ensure always validate current plugin list

### DIFF
--- a/libinstall/src/InternetDownload.cpp
+++ b/libinstall/src/InternetDownload.cpp
@@ -71,7 +71,7 @@ void InternetDownload::statusCallback( HINTERNET /* hInternet */,
 
 }
 void InternetDownload::disableCache() {
-    m_flags = INTERNET_FLAG_NO_CACHE_WRITE | INTERNET_FLAG_PRAGMA_NOCACHE;
+    m_flags = INTERNET_FLAG_PRAGMA_NOCACHE | INTERNET_FLAG_RESYNCHRONIZE;
 }
 
 BOOL InternetDownload::request() {

--- a/pluginManager/src/PluginList.cpp
+++ b/pluginManager/src/PluginList.cpp
@@ -894,7 +894,8 @@ void PluginList::downloadList()
 	TCHAR hashBuffer[(MD5LEN * 2) + 1];
 	MD5::hash(pluginsListFilename.c_str(), hashBuffer, (MD5LEN * 2) + 1);
 	string serverMD5;
-    BOOL downloadSuccess = FALSE;
+	BOOL downloadSuccess = FALSE;
+	downloadManager.disableCache();
 
 #ifdef ALLOW_OVERRIDE_XML_URL
 	BOOL downloadResult;


### PR DESCRIPTION
The caching creates more issues than it solves - it will still be cached by cloudflare in production, but the dev list will be instantly updated (as soon as it's available on the server)